### PR TITLE
Removing refresh token from tap xero

### DIFF
--- a/tap_xero/__init__.py
+++ b/tap_xero/__init__.py
@@ -13,7 +13,7 @@ REQUIRED_CONFIG_KEYS = [
     "client_id",
     "client_secret",
     "tenant_id",
-    "refresh_token",
+    "access_token",
 
 ]
 


### PR DESCRIPTION
# Description of change
Removing refresh token from tap xero, this is not required as we use Nango to manage this.

# Manual QA steps
 - 
 
# Risks
 - 
 
# Rollback steps
 - revert this branch
